### PR TITLE
feat(1): Schema Migration & Category Fix

### DIFF
--- a/backend/db/migrate.js
+++ b/backend/db/migrate.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Idempotent migration runner.
+ * Uses PRAGMA user_version to track applied migrations.
+ * Safe to call on every server startup.
+ */
+function runMigration(db) {
+  let version = db.pragma('user_version', { simple: true });
+
+  // ─── Migration 1: Remove 'reflect' category from tasks table ───────────────
+  if (version < 1) {
+    db.exec(`
+      CREATE TABLE tasks_new (
+        id                TEXT PRIMARY KEY,
+        mission_id        TEXT REFERENCES missions(id) ON DELETE SET NULL,
+        name              TEXT NOT NULL,
+        description       TEXT NOT NULL DEFAULT '',
+        priority          TEXT NOT NULL DEFAULT 'medium'
+                          CHECK(priority IN ('high','medium','low')),
+        category          TEXT NOT NULL DEFAULT 'other'
+                          CHECK(category IN ('explore','learn','build','integrate','office-hours','other')),
+        estimated_minutes INTEGER NOT NULL DEFAULT 30,
+        completed         INTEGER NOT NULL DEFAULT 0,
+        created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      INSERT INTO tasks_new
+        SELECT
+          id, mission_id, name, description, priority,
+          CASE WHEN category = 'reflect' THEN 'other' ELSE category END,
+          estimated_minutes, completed, created_at, updated_at
+        FROM tasks;
+
+      DROP TABLE tasks;
+      ALTER TABLE tasks_new RENAME TO tasks;
+    `);
+
+    // Remove 'reflect' from stored allotments config
+    const row = db.prepare("SELECT value FROM config WHERE key = 'allotments'").get();
+    if (row) {
+      const allotments = JSON.parse(row.value);
+      delete allotments.reflect;
+      db.prepare(
+        "UPDATE config SET value = ? WHERE key = 'allotments'"
+      ).run(JSON.stringify(allotments));
+    }
+
+    db.pragma('user_version = 1');
+    version = 1;
+  }
+
+  // ─── Migration 2: Replace schedule_overrides with schedule_slots ────────────
+  if (version < 2) {
+    // Create the new table
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS schedule_slots (
+        id          TEXT PRIMARY KEY,
+        date        TEXT NOT NULL,
+        slot_index  INTEGER NOT NULL,
+        record_type TEXT NOT NULL DEFAULT 'planned'
+                    CHECK(record_type IN ('planned','actual')),
+        task_id     TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+        label       TEXT,
+        UNIQUE(date, slot_index, record_type)
+      );
+    `);
+
+    // Migrate existing data from schedule_overrides if the table still exists
+    const hasOverrides = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='schedule_overrides'"
+    ).get();
+
+    if (hasOverrides) {
+      db.exec(`
+        INSERT OR IGNORE INTO schedule_slots (id, date, slot_index, record_type, task_id, label)
+          SELECT id, date, slot_index, 'planned', task_id, label
+          FROM schedule_overrides;
+
+        DROP TABLE schedule_overrides;
+      `);
+    }
+
+    db.pragma('user_version = 2');
+  }
+}
+
+module.exports = { runMigration };

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   name              TEXT NOT NULL,
   description       TEXT NOT NULL DEFAULT '',
   priority          TEXT NOT NULL DEFAULT 'medium' CHECK(priority IN ('high','medium','low')),
-  category          TEXT NOT NULL DEFAULT 'other'  CHECK(category IN ('explore','learn','build','integrate','reflect','office-hours','other')),
+  category          TEXT NOT NULL DEFAULT 'other'  CHECK(category IN ('explore','learn','build','integrate','office-hours','other')),
   estimated_minutes INTEGER NOT NULL DEFAULT 30,
   completed         INTEGER NOT NULL DEFAULT 0,
   created_at        TEXT NOT NULL DEFAULT (datetime('now')),
@@ -36,15 +36,16 @@ CREATE TABLE IF NOT EXISTS config (
 
 INSERT OR IGNORE INTO config (key, value) VALUES (
   'allotments',
-  '{"explore":60,"learn":120,"build":180,"integrate":60,"reflect":30,"office-hours":60,"other":60}'
+  '{"explore":60,"learn":120,"build":180,"integrate":60,"office-hours":60,"other":60}'
 );
 
-CREATE TABLE IF NOT EXISTS schedule_overrides (
-  id         TEXT PRIMARY KEY,
-  date       TEXT NOT NULL,
-  slot_index INTEGER NOT NULL,
-  task_id    TEXT REFERENCES tasks(id) ON DELETE SET NULL,
-  label      TEXT,
-  is_actual  INTEGER NOT NULL DEFAULT 0,
-  UNIQUE(date, slot_index)
+CREATE TABLE IF NOT EXISTS schedule_slots (
+  id          TEXT PRIMARY KEY,
+  date        TEXT NOT NULL,
+  slot_index  INTEGER NOT NULL,
+  record_type TEXT NOT NULL DEFAULT 'planned'
+              CHECK(record_type IN ('planned','actual')),
+  task_id     TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+  label       TEXT,
+  UNIQUE(date, slot_index, record_type)
 );

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,11 @@ require('dotenv').config();
 const express = require('express');
 const cors    = require('cors');
 
+// Run DB schema init + migrations before any route handlers load
+const db                 = require('./db/database');
+const { runMigration }   = require('./db/migrate');
+runMigration(db);
+
 const tasksRouter    = require('./routes/tasks');
 const missionsRouter = require('./routes/missions');
 const configRouter   = require('./routes/config');

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,4 +1,4 @@
-export const CATEGORIES = ['explore', 'learn', 'build', 'integrate', 'reflect', 'office-hours', 'other'];
+export const CATEGORIES = ['explore', 'learn', 'build', 'integrate', 'office-hours', 'other'];
 export const PRIORITIES  = ['high', 'medium', 'low'];
 
 export const CATEGORY_COLORS = {
@@ -6,7 +6,6 @@ export const CATEGORY_COLORS = {
   learn:          '#3b82f6',
   build:          '#10b981',
   integrate:      '#f59e0b',
-  reflect:        '#ec4899',
   'office-hours': '#6366f1',
   other:          '#64748b',
 };


### PR DESCRIPTION
Feature #1 for Issue #9

## Changes

### Backend
- **`backend/db/migrate.js`** (new): Idempotent migration runner using `PRAGMA user_version`
  - v0→v1: Recreates `tasks` table without `reflect` in CHECK constraint; remaps any existing `reflect` rows to `other`; removes `reflect` from config allotments
  - v1→v2: Replaces `schedule_overrides` table with `schedule_slots` — adds `record_type` column (`planned`|`actual`) and changes UNIQUE constraint to `(date, slot_index, record_type)` to allow both a planned and actual record per slot
- **`backend/server.js`**: Calls `runMigration(db)` on startup before route handlers
- **`backend/db/schema.sql`**: Updated as source of truth for fresh DBs — no `reflect`, `schedule_slots` table, corrected allotments default

### Frontend
- **`frontend/src/utils.js`**: Removed `reflect` from `CATEGORIES` array and `CATEGORY_COLORS` object — AllotmentModal and TaskModal automatically benefit (both iterate `CATEGORIES` dynamically)

## Acceptance Criteria

- [x] Server starts cleanly on a fresh DB
- [x] Server starts cleanly on an existing DB (migration is idempotent)
- [x] tasks table CHECK no longer includes `reflect`
- [x] Existing `reflect` tasks remapped to `other`
- [x] `schedule_slots` table exists with correct schema (date, slot_index, record_type UNIQUE)
- [x] Frontend task creation form has no reflect option
- [x] Allotment bars show no reflect row

---
*Created by Antigravity Dev Agent*