### PR TITLE
fix(1): QA fixes — FK safety, transactions, reflect cleanup

### DIFF
--- a/backend/db/migrate.js
+++ b/backend/db/migrate.js
@@ -4,85 +4,101 @@
  * Idempotent migration runner.
  * Uses PRAGMA user_version to track applied migrations.
  * Safe to call on every server startup.
+ *
+ * Each migration step:
+ *   - Disables FK enforcement so DROP TABLE doesn't cascade-null task_id refs.
+ *   - Wraps DDL + data changes in a transaction for crash safety.
+ *   - Re-enables FK enforcement after the transaction commits.
  */
 function runMigration(db) {
   let version = db.pragma('user_version', { simple: true });
 
   // ─── Migration 1: Remove 'reflect' category from tasks table ───────────────
   if (version < 1) {
-    db.exec(`
-      CREATE TABLE tasks_new (
-        id                TEXT PRIMARY KEY,
-        mission_id        TEXT REFERENCES missions(id) ON DELETE SET NULL,
-        name              TEXT NOT NULL,
-        description       TEXT NOT NULL DEFAULT '',
-        priority          TEXT NOT NULL DEFAULT 'medium'
-                          CHECK(priority IN ('high','medium','low')),
-        category          TEXT NOT NULL DEFAULT 'other'
-                          CHECK(category IN ('explore','learn','build','integrate','office-hours','other')),
-        estimated_minutes INTEGER NOT NULL DEFAULT 30,
-        completed         INTEGER NOT NULL DEFAULT 0,
-        created_at        TEXT NOT NULL DEFAULT (datetime('now')),
-        updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
-      );
+    db.pragma('foreign_keys = OFF');
 
-      INSERT INTO tasks_new
-        SELECT
-          id, mission_id, name, description, priority,
-          CASE WHEN category = 'reflect' THEN 'other' ELSE category END,
-          estimated_minutes, completed, created_at, updated_at
-        FROM tasks;
+    db.transaction(() => {
+      db.exec(`
+        CREATE TABLE tasks_new (
+          id                TEXT PRIMARY KEY,
+          mission_id        TEXT REFERENCES missions(id) ON DELETE SET NULL,
+          name              TEXT NOT NULL,
+          description       TEXT NOT NULL DEFAULT '',
+          priority          TEXT NOT NULL DEFAULT 'medium'
+                            CHECK(priority IN ('high','medium','low')),
+          category          TEXT NOT NULL DEFAULT 'other'
+                            CHECK(category IN ('explore','learn','build','integrate','office-hours','other')),
+          estimated_minutes INTEGER NOT NULL DEFAULT 30,
+          completed         INTEGER NOT NULL DEFAULT 0,
+          created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+        );
 
-      DROP TABLE tasks;
-      ALTER TABLE tasks_new RENAME TO tasks;
-    `);
+        INSERT INTO tasks_new
+          SELECT
+            id, mission_id, name, description, priority,
+            CASE WHEN category = 'reflect' THEN 'other' ELSE category END,
+            estimated_minutes, completed, created_at, updated_at
+          FROM tasks;
 
-    // Remove 'reflect' from stored allotments config
-    const row = db.prepare("SELECT value FROM config WHERE key = 'allotments'").get();
-    if (row) {
-      const allotments = JSON.parse(row.value);
-      delete allotments.reflect;
-      db.prepare(
-        "UPDATE config SET value = ? WHERE key = 'allotments'"
-      ).run(JSON.stringify(allotments));
-    }
+        DROP TABLE tasks;
+        ALTER TABLE tasks_new RENAME TO tasks;
+      `);
 
-    db.pragma('user_version = 1');
+      // Remove 'reflect' from stored allotments config
+      const row = db.prepare("SELECT value FROM config WHERE key = 'allotments'").get();
+      if (row) {
+        const allotments = JSON.parse(row.value);
+        delete allotments.reflect;
+        db.prepare(
+          "UPDATE config SET value = ? WHERE key = 'allotments'"
+        ).run(JSON.stringify(allotments));
+      }
+
+      db.exec('PRAGMA user_version = 1');
+    })();
+
+    db.pragma('foreign_keys = ON');
     version = 1;
   }
 
   // ─── Migration 2: Replace schedule_overrides with schedule_slots ────────────
   if (version < 2) {
-    // Create the new table
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS schedule_slots (
-        id          TEXT PRIMARY KEY,
-        date        TEXT NOT NULL,
-        slot_index  INTEGER NOT NULL,
-        record_type TEXT NOT NULL DEFAULT 'planned'
-                    CHECK(record_type IN ('planned','actual')),
-        task_id     TEXT REFERENCES tasks(id) ON DELETE SET NULL,
-        label       TEXT,
-        UNIQUE(date, slot_index, record_type)
-      );
-    `);
+    db.pragma('foreign_keys = OFF');
 
-    // Migrate existing data from schedule_overrides if the table still exists
-    const hasOverrides = db.prepare(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name='schedule_overrides'"
-    ).get();
-
-    if (hasOverrides) {
+    db.transaction(() => {
       db.exec(`
-        INSERT OR IGNORE INTO schedule_slots (id, date, slot_index, record_type, task_id, label)
-          SELECT id, date, slot_index, 'planned', task_id, label
-          FROM schedule_overrides;
-
-        DROP TABLE schedule_overrides;
+        CREATE TABLE IF NOT EXISTS schedule_slots (
+          id          TEXT PRIMARY KEY,
+          date        TEXT NOT NULL,
+          slot_index  INTEGER NOT NULL,
+          record_type TEXT NOT NULL DEFAULT 'planned'
+                      CHECK(record_type IN ('planned','actual')),
+          task_id     TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+          label       TEXT,
+          UNIQUE(date, slot_index, record_type)
+        );
       `);
-    }
 
-    db.pragma('user_version = 2');
+      // Migrate existing data from schedule_overrides if the table still exists
+      const hasOverrides = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='schedule_overrides'"
+      ).get();
+
+      if (hasOverrides) {
+        db.exec(`
+          INSERT OR IGNORE INTO schedule_slots (id, date, slot_index, record_type, task_id, label)
+            SELECT id, date, slot_index, 'planned', task_id, label
+            FROM schedule_overrides;
+
+          DROP TABLE schedule_overrides;
+        `);
+      }
+
+      db.exec('PRAGMA user_version = 2');
+    })();
+
+    db.pragma('foreign_keys = ON');
   }
 }
 

--- a/backend/routes/ai.js
+++ b/backend/routes/ai.js
@@ -51,7 +51,7 @@ router.post('/estimate', async (req, res) => {
   const systemPrompt = `You are a task estimation assistant. Given a task name and description, respond ONLY with valid JSON in this exact shape:
 {
   "estimatedMinutes": <integer>,
-  "suggestedCategory": "<one of: explore|learn|build|integrate|reflect|office-hours|other>",
+  "suggestedCategory": "<one of: explore|learn|build|integrate|office-hours|other>",
   "suggestedSubtasks": [{ "name": "<string>" }, ...]
 }
 Provide 3-5 subtasks. Be concise.`;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,7 +23,6 @@
   --cat-learn:        #3b82f6;
   --cat-build:        #10b981;
   --cat-integrate:    #f59e0b;
-  --cat-reflect:      #ec4899;
   --cat-office-hours: #6366f1;
   --cat-other:        #64748b;
 


### PR DESCRIPTION
Feature #1 QA fix for Issue #9 (cycle 1)

## Fixes Applied

### [CRITICAL] Foreign Key Safety in Migration
****: Added `PRAGMA foreign_keys = OFF` before each migration step and `PRAGMA foreign_keys = ON` after. Without this, SQLite's cascade-delete rule would nullify all `task_id` references in `schedule_overrides`/`schedule_slots` when `DROP TABLE tasks` executes.

### [MEDIUM] Crash-Safe Transactions
****: Wrapped each migration step (v0→v1, v1→v2) in `db.transaction(() => { ... })()`. The `PRAGMA user_version` bump is inside the transaction so a partial migration is fully rolled back on crash — no half-applied state.

### [MEDIUM] Remove reflect from LLM Prompt
****: Removed `reflect` from the `suggestedCategory` field description in the AI estimation system prompt. Was: `explore|learn|build|integrate|reflect|office-hours|other`. Now: `explore|learn|build|integrate|office-hours|other`.

### [MINOR] Remove CSS Variable
****: Removed `--cat-reflect: #ec4899` CSS variable from .

---
*Created by Antigravity Dev Agent*