### PR TITLE
feat(2): Schedule Generation Backend API

### DIFF
--- a/backend/routes/schedule.js
+++ b/backend/routes/schedule.js
@@ -1,55 +1,226 @@
 'use strict';
 
-const { Router } = require('express');
+const { Router }    = require('express');
 const { randomUUID } = require('crypto');
-const db = require('../db/database');
+const db             = require('../db/database');
 
 const router = Router();
 
-// GET /api/schedule/overrides?date=YYYY-MM-DD
-router.get('/overrides', (req, res) => {
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const CATEGORY_ORDER = ['explore', 'learn', 'build', 'integrate', 'office-hours', 'other'];
+const PRIORITY_RANK  = { high: 0, medium: 1, low: 2 };
+const START_SLOT     = 32;   // 08:00 (32 × 15 min)
+const MAX_SLOT       = 95;   // 23:45
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Join a schedule_slots row with its task data.
+ * Returns the row augmented with a `task` object (or null).
+ */
+const SLOT_JOIN_SQL = `
+  SELECT
+    ss.id, ss.date, ss.slot_index, ss.record_type, ss.task_id, ss.label,
+    t.name        AS task_name,
+    t.description AS task_description,
+    t.category    AS task_category
+  FROM schedule_slots ss
+  LEFT JOIN tasks t ON t.id = ss.task_id
+  WHERE ss.date = ? AND ss.record_type = ?
+  ORDER BY ss.slot_index ASC
+`;
+
+function formatSlots(rows) {
+  return rows.map(r => ({
+    id:          r.id,
+    date:        r.date,
+    slot_index:  r.slot_index,
+    record_type: r.record_type,
+    task_id:     r.task_id,
+    label:       r.label,
+    task: r.task_id ? {
+      name:        r.task_name,
+      description: r.task_description,
+      category:    r.task_category,
+    } : null,
+  }));
+}
+
+// ─── POST /api/schedule/generate ────────────────────────────────────────────
+
+router.post('/generate', (req, res) => {
+  const { date } = req.body;
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return res.status(400).json({ error: 'date is required (YYYY-MM-DD)' });
+  }
+
+  // 1. Load allotments from config
+  const configRow  = db.prepare("SELECT value FROM config WHERE key = 'allotments'").get();
+  const allotments = configRow ? JSON.parse(configRow.value) : {};
+
+  // 2. Load all incomplete tasks
+  const tasks = db.prepare(
+    'SELECT * FROM tasks WHERE completed = 0 ORDER BY created_at ASC'
+  ).all();
+
+  // 3. Group tasks by category
+  const byCategory = {};
+  for (const cat of CATEGORY_ORDER) byCategory[cat] = [];
+  for (const task of tasks) {
+    if (byCategory[task.category]) {
+      byCategory[task.category].push(task);
+    } else {
+      byCategory['other'].push(task);
+    }
+  }
+
+  // 4. Sort each group: high → medium → low, then created_at ASC (already in created_at ASC order)
+  for (const cat of CATEGORY_ORDER) {
+    byCategory[cat].sort((a, b) => {
+      const pd = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+      if (pd !== 0) return pd;
+      // created_at ASC — tasks were loaded in this order already; preserve stability
+      return a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0;
+    });
+  }
+
+  // 5. Fill slots
+  const slots = [];     // { slot_index, task_id, label }
+  let currentSlot = START_SLOT;
+
+  for (const cat of CATEGORY_ORDER) {
+    const catTasks   = byCategory[cat];
+    const allottedMs = allotments[cat] ?? 0;
+    let   capSlots   = Math.ceil(allottedMs / 15);   // slots this category may consume
+
+    if (capSlots <= 0 || catTasks.length === 0) continue;
+
+    for (const task of catTasks) {
+      if (capSlots <= 0 || currentSlot > MAX_SLOT) break;
+
+      const taskSlots  = Math.ceil((task.estimated_minutes || 15) / 15);
+      const toSchedule = Math.min(taskSlots, capSlots, MAX_SLOT - currentSlot + 1);
+
+      for (let i = 0; i < toSchedule; i++) {
+        slots.push({
+          slot_index: currentSlot + i,
+          task_id:    task.id,
+          label:      toSchedule < taskSlots ? task.name + ' [cont.]' : null,
+        });
+      }
+
+      currentSlot += toSchedule;
+      capSlots    -= toSchedule;
+    }
+  }
+
+  // 6. Persist — delete existing planned rows then bulk-insert inside a transaction
+  const insert = db.prepare(`
+    INSERT INTO schedule_slots (id, date, slot_index, record_type, task_id, label)
+    VALUES (?, ?, ?, 'planned', ?, ?)
+  `);
+
+  db.transaction(() => {
+    db.prepare(
+      "DELETE FROM schedule_slots WHERE date = ? AND record_type = 'planned'"
+    ).run(date);
+
+    for (const s of slots) {
+      insert.run(randomUUID(), date, s.slot_index, s.task_id, s.label);
+    }
+  })();
+
+  // 7. Return the inserted slots joined with task data
+  const rows = db.prepare(SLOT_JOIN_SQL).all(date, 'planned');
+  return res.json({ slots: formatSlots(rows) });
+});
+
+// ─── GET /api/schedule?date=YYYY-MM-DD ──────────────────────────────────────
+
+router.get('/', (req, res) => {
   const { date } = req.query;
   if (!date) return res.status(400).json({ error: 'date query param required (YYYY-MM-DD)' });
 
-  const rows = db.prepare(
-    'SELECT * FROM schedule_overrides WHERE date = ? ORDER BY slot_index ASC'
-  ).all(date);
+  const planned = db.prepare(SLOT_JOIN_SQL).all(date, 'planned');
+  const actual  = db.prepare(SLOT_JOIN_SQL).all(date, 'actual');
 
-  res.json(rows.map(r => ({ ...r, is_actual: !!r.is_actual })));
+  return res.json({
+    planned: formatSlots(planned),
+    actual:  formatSlots(actual),
+  });
 });
 
-// PUT /api/schedule/overrides  — upserts by (date, slot_index)
-// body: { date, slot_index, task_id?, label?, is_actual? }
-router.put('/overrides', (req, res) => {
-  const { date, slot_index, task_id = null, label = null, is_actual = 0 } = req.body;
+// ─── DELETE /api/schedule?date=YYYY-MM-DD ───────────────────────────────────
+
+router.delete('/', (req, res) => {
+  const { date } = req.query;
+  if (!date) return res.status(400).json({ error: 'date query param required (YYYY-MM-DD)' });
+
+  const result = db.prepare(
+    "DELETE FROM schedule_slots WHERE date = ? AND record_type = 'planned'"
+  ).run(date);
+
+  return res.json({ deleted: result.changes });
+});
+
+// ─── PUT /api/schedule/slots ─────────────────────────────────────────────────
+
+router.put('/slots', (req, res) => {
+  const {
+    date,
+    slot_index,
+    record_type = 'planned',
+    task_id     = null,
+    label       = null,
+  } = req.body;
 
   if (!date || slot_index === undefined) {
     return res.status(400).json({ error: 'date and slot_index are required' });
   }
+  if (!['planned', 'actual'].includes(record_type)) {
+    return res.status(400).json({ error: 'record_type must be planned or actual' });
+  }
 
-  // Check whether a row already exists
+  // Upsert by (date, slot_index, record_type)
   const existing = db.prepare(
-    'SELECT id FROM schedule_overrides WHERE date = ? AND slot_index = ?'
-  ).get(date, slot_index);
+    'SELECT id FROM schedule_slots WHERE date = ? AND slot_index = ? AND record_type = ?'
+  ).get(date, slot_index, record_type);
 
   if (existing) {
     db.prepare(
-      `UPDATE schedule_overrides
-       SET task_id = ?, label = ?, is_actual = ?
-       WHERE date = ? AND slot_index = ?`
-    ).run(task_id, label, is_actual ? 1 : 0, date, slot_index);
+      `UPDATE schedule_slots SET task_id = ?, label = ?
+       WHERE date = ? AND slot_index = ? AND record_type = ?`
+    ).run(task_id, label, date, slot_index, record_type);
   } else {
     db.prepare(
-      `INSERT INTO schedule_overrides (id, date, slot_index, task_id, label, is_actual)
+      `INSERT INTO schedule_slots (id, date, slot_index, record_type, task_id, label)
        VALUES (?, ?, ?, ?, ?, ?)`
-    ).run(randomUUID(), date, slot_index, task_id, label, is_actual ? 1 : 0);
+    ).run(randomUUID(), date, slot_index, record_type, task_id, label);
   }
 
-  const row = db.prepare(
-    'SELECT * FROM schedule_overrides WHERE date = ? AND slot_index = ?'
-  ).get(date, slot_index);
+  const row = db.prepare(`
+    SELECT
+      ss.id, ss.date, ss.slot_index, ss.record_type, ss.task_id, ss.label,
+      t.name AS task_name, t.description AS task_description, t.category AS task_category
+    FROM schedule_slots ss
+    LEFT JOIN tasks t ON t.id = ss.task_id
+    WHERE ss.date = ? AND ss.slot_index = ? AND ss.record_type = ?
+  `).get(date, slot_index, record_type);
 
-  res.json({ ...row, is_actual: !!row.is_actual });
+  return res.json({
+    id:          row.id,
+    date:        row.date,
+    slot_index:  row.slot_index,
+    record_type: row.record_type,
+    task_id:     row.task_id,
+    label:       row.label,
+    task: row.task_id ? {
+      name:        row.task_name,
+      description: row.task_description,
+      category:    row.task_category,
+    } : null,
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
Feature #2 for Issue #9

## Endpoints

### POST /api/schedule/generate
- Accepts `{ date: "YYYY-MM-DD" }`
- Loads incomplete tasks + allotments from config
- Groups tasks by category; sorts each group high→medium→low priority then `created_at` ASC
- Fills 15-min slots from slot 32 (08:00) in category order: explore→learn→build→integrate→office-hours→other
- Respects each category allotment cap (`ceil(minutes/15)` slots)
- Deletes existing planned rows + bulk-inserts new ones in a single transaction
- Returns `{ slots: [{id, slot_index, record_type, task_id, label, task}] }`

### GET /api/schedule?date=YYYY-MM-DD
- Returns `{ planned: [...], actual: [...] }`
- Each slot LEFT JOINed with task `name`, `description`, `category`

### DELETE /api/schedule?date=YYYY-MM-DD
- Deletes only `record_type=planned` rows; returns `{ deleted: N }`
- Actual rows survive unchanged

### PUT /api/schedule/slots
- Body: `{ date, slot_index, record_type, task_id?, label? }`
- Upserts by `(date, slot_index, record_type)`
- Returns the upserted slot joined with task data

## Acceptance Criteria
- [x] Generate endpoint returns slots respecting category allotment caps
- [x] High-priority tasks appear before lower-priority within the same category
- [x] GET returns separate planned/actual arrays with joined task data
- [x] DELETE removes only planned rows; actual rows survive

---
*Created by Antigravity Dev Agent*