### PR TITLE
feat(3): Daily Schedule Grid UI with Auto-Generation

### DIFF
--- a/frontend/src/components/ScheduleGrid.css
+++ b/frontend/src/components/ScheduleGrid.css
@@ -1,0 +1,207 @@
+/* ─── Container ───────────────────────────────────────────────────────────── */
+
+.schedule-grid {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+/* ─── Header ──────────────────────────────────────────────────────────────── */
+
+.sg-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--border-glass);
+  flex-shrink: 0;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.sg-date {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sg-date-icon {
+  font-size: 1.1rem;
+}
+
+.sg-date-label {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.sg-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* ─── Plan / Actual toggle ────────────────────────────────────────────────── */
+
+.sg-view-toggle {
+  display: flex;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-glass);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.sg-toggle-btn {
+  padding: 6px 16px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: background var(--transition), color var(--transition);
+}
+
+.sg-toggle-btn.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.sg-toggle-btn:not(.active):hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text-primary);
+}
+
+/* ─── Generate button ─────────────────────────────────────────────────────── */
+
+.sg-generate-btn {
+  font-size: 0.85rem;
+  padding: 7px 16px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* ─── Error banner ────────────────────────────────────────────────────────── */
+
+.sg-error {
+  padding: 8px 20px;
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+  font-size: 0.85rem;
+  border-bottom: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+/* ─── Scrollable table area ───────────────────────────────────────────────── */
+
+.sg-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.sg-scroll::-webkit-scrollbar { width: 6px; }
+.sg-scroll::-webkit-scrollbar-track { background: transparent; }
+.sg-scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+.sg-scroll::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.2); }
+
+/* ─── Table ───────────────────────────────────────────────────────────────── */
+
+.sg-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.sg-th {
+  position: sticky;
+  top: 0;
+  background: var(--bg-elevated);
+  z-index: 1;
+  padding: 8px 12px;
+  text-align: left;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-glass);
+}
+
+.sg-th-time  { width: 80px; }
+.sg-th-task  { width: 35%; }
+.sg-th-desc  { /* flex remaining */ }
+
+/* ─── Row styles ──────────────────────────────────────────────────────────── */
+
+.sg-row {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  border-left: 4px solid transparent;   /* placeholder — overridden inline for occupied */
+  transition: background var(--transition);
+}
+
+.sg-row-empty {
+  opacity: 0.45;
+}
+
+.sg-row-occupied {
+  opacity: 1;
+}
+
+.sg-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.sg-td {
+  padding: 5px 12px;
+  vertical-align: middle;
+  font-size: 0.82rem;
+}
+
+.sg-td-time {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+/* ─── Task cell ───────────────────────────────────────────────────────────── */
+
+.sg-task-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-primary);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sg-cat-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.sg-empty-label {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ─── Description cell ────────────────────────────────────────────────────── */
+
+.sg-task-desc {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/frontend/src/components/ScheduleGrid.jsx
+++ b/frontend/src/components/ScheduleGrid.jsx
@@ -1,0 +1,151 @@
+import React, { useState, useCallback } from 'react';
+import { useApp } from '../context/AppContext.jsx';
+import { CATEGORY_COLORS, todayISO } from '../utils.js';
+import './ScheduleGrid.css';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const TOTAL_SLOTS = 96;   // 15-min slots in 24 hours
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function slotToTime(index) {
+  const totalMins = index * 15;
+  const h24       = Math.floor(totalMins / 60) % 24;
+  const m         = totalMins % 60;
+  const ampm      = h24 < 12 ? 'AM' : 'PM';
+  const h12       = h24 === 0 ? 12 : h24 > 12 ? h24 - 12 : h24;
+  return `${h12}:${String(m).padStart(2, '0')} ${ampm}`;
+}
+
+function formatDate(iso) {
+  const d = new Date(iso + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+// ─── ScheduleGrid ─────────────────────────────────────────────────────────────
+
+export default function ScheduleGrid() {
+  const { schedule, generateSchedule } = useApp();
+
+  // 'planned' | 'actual' — ephemeral UI state, lives here not in context
+  const [view,        setView]        = useState('planned');
+  const [generating,  setGenerating]  = useState(false);
+  const [genError,    setGenError]    = useState('');
+
+  const date   = schedule.date ?? todayISO();
+  const slots  = view === 'actual' ? schedule.actual : schedule.planned;
+
+  // Build a lookup: slot_index → slot object
+  const slotMap = {};
+  for (const s of slots) slotMap[s.slot_index] = s;
+
+  const handleGenerate = useCallback(async () => {
+    setGenerating(true);
+    setGenError('');
+    try {
+      await generateSchedule(date);
+    } catch {
+      setGenError('Failed to generate schedule. Please try again.');
+    } finally {
+      setGenerating(false);
+    }
+  }, [date, generateSchedule]);
+
+  return (
+    <div className="schedule-grid glass-card">
+      {/* ── Header ──────────────────────────────────────────────────────── */}
+      <div className="sg-header">
+        <div className="sg-date">
+          <span className="sg-date-icon">📅</span>
+          <span className="sg-date-label">{formatDate(date)}</span>
+        </div>
+
+        <div className="sg-header-actions">
+          {/* Plan / Actual toggle */}
+          <div className="sg-view-toggle">
+            <button
+              className={`sg-toggle-btn ${view === 'planned' ? 'active' : ''}`}
+              onClick={() => setView('planned')}
+            >
+              Plan
+            </button>
+            <button
+              className={`sg-toggle-btn ${view === 'actual' ? 'active' : ''}`}
+              onClick={() => setView('actual')}
+            >
+              Actual
+            </button>
+          </div>
+
+          {/* Generate button */}
+          <button
+            className="btn btn-primary sg-generate-btn"
+            onClick={handleGenerate}
+            disabled={generating}
+          >
+            {generating ? (
+              <><span className="spinner" style={{ width: 14, height: 14 }} /> Generating…</>
+            ) : (
+              '⟳ Generate Schedule'
+            )}
+          </button>
+        </div>
+      </div>
+
+      {genError && <div className="sg-error">{genError}</div>}
+
+      {/* ── Table ───────────────────────────────────────────────────────── */}
+      <div className="sg-scroll">
+        <table className="sg-table">
+          <thead>
+            <tr>
+              <th className="sg-th sg-th-time">Time</th>
+              <th className="sg-th sg-th-task">Task / Label</th>
+              <th className="sg-th sg-th-desc">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: TOTAL_SLOTS }, (_, i) => {
+              const slot     = slotMap[i];
+              const occupied = !!slot;
+              const category = slot?.task?.category;
+              const color    = category ? CATEGORY_COLORS[category] : null;
+
+              return (
+                <tr
+                  key={i}
+                  className={`sg-row ${occupied ? 'sg-row-occupied' : 'sg-row-empty'}`}
+                  style={color ? { borderLeft: `4px solid ${color}` } : undefined}
+                >
+                  <td className="sg-td sg-td-time">{slotToTime(i)}</td>
+                  <td className="sg-td sg-td-task">
+                    {occupied ? (
+                      <div className="sg-task-name">
+                        {category && (
+                          <span
+                            className="sg-cat-dot"
+                            style={{ background: color }}
+                            title={category}
+                          />
+                        )}
+                        {slot.label ?? slot.task?.name ?? '—'}
+                      </div>
+                    ) : (
+                      <span className="sg-empty-label">—</span>
+                    )}
+                  </td>
+                  <td className="sg-td sg-td-desc">
+                    {occupied && slot.task?.description ? (
+                      <span className="sg-task-desc">{slot.task.description}</span>
+                    ) : null}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/context/AppContext.jsx
+++ b/frontend/src/context/AppContext.jsx
@@ -7,11 +7,15 @@ function todayISO() {
 }
 
 const initialState = {
-  tasks:     [],
-  missions:  [],
+  tasks:      [],
+  missions:   [],
   allotments: {},
-  overrides:  [],
-  loading:   true,
+  schedule: {
+    date:    todayISO(),
+    planned: [],   // [{ id, slot_index, record_type, task_id, label, task }]
+    actual:  [],   // [{ id, slot_index, record_type, task_id, label, task }]
+  },
+  loading: true,
 };
 
 function reducer(state, action) {
@@ -42,15 +46,22 @@ function reducer(state, action) {
     case 'SET_ALLOTMENTS':
       return { ...state, allotments: action.payload };
 
-    case 'UPSERT_OVERRIDE': {
-      const { date, slot_index } = action.payload;
-      const existing = state.overrides.find(o => o.date === date && o.slot_index === slot_index);
-      return {
-        ...state,
-        overrides: existing
-          ? state.overrides.map(o => (o.date === date && o.slot_index === slot_index) ? action.payload : o)
-          : [...state.overrides, action.payload],
-      };
+    // ── Schedule ───────────────────────────────────────────────────────────
+    case 'SET_SCHEDULE':
+      return { ...state, schedule: { ...state.schedule, ...action.payload } };
+
+    case 'SET_PLANNED_SLOTS':
+      return { ...state, schedule: { ...state.schedule, planned: action.payload } };
+
+    case 'UPSERT_SLOT': {
+      const slot = action.payload;
+      const key  = slot.record_type === 'actual' ? 'actual' : 'planned';
+      const arr  = state.schedule[key];
+      const idx  = arr.findIndex(s => s.slot_index === slot.slot_index);
+      const next = idx >= 0
+        ? arr.map((s, i) => i === idx ? slot : s)
+        : [...arr, slot].sort((a, b) => a.slot_index - b.slot_index);
+      return { ...state, schedule: { ...state.schedule, [key]: next } };
     }
 
     default:
@@ -67,14 +78,33 @@ export function AppProvider({ children }) {
       fetch('/api/tasks').then(r => r.json()),
       fetch('/api/missions').then(r => r.json()),
       fetch('/api/config').then(r => r.json()),
-      fetch(`/api/schedule/overrides?date=${today}`).then(r => r.json()),
-    ]).then(([tasks, missions, config, overrides]) => {
+      fetch(`/api/schedule?date=${today}`).then(r => r.json()),
+    ]).then(([tasks, missions, config, schedule]) => {
+      const planned = schedule.planned || [];
+      const actual  = schedule.actual  || [];
+
       dispatch({ type: 'INIT', payload: {
         tasks,
         missions,
         allotments: config.allotments || {},
-        overrides,
+        schedule: { date: today, planned, actual },
       }});
+
+      // Auto-generate if no planned slots exist for today
+      if (planned.length === 0) {
+        fetch('/api/schedule/generate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ date: today }),
+        })
+          .then(r => r.json())
+          .then(data => {
+            if (data.slots) {
+              dispatch({ type: 'SET_PLANNED_SLOTS', payload: data.slots });
+            }
+          })
+          .catch(() => {/* silent — no planned schedule today, that's OK */});
+      }
     }).catch(() => {
       dispatch({ type: 'INIT', payload: {} });
     });
@@ -199,18 +229,42 @@ export function AppProvider({ children }) {
     dispatch({ type: 'UPDATE_TASK', payload: task });
   }, []);
 
-  // ── Schedule overrides ────────────────────────────────────────────────────
+  // ── Schedule ──────────────────────────────────────────────────────────────
 
-  const upsertOverride = useCallback(async (data) => {
-    const res = await fetch('/api/schedule/overrides', {
+  const fetchSchedule = useCallback(async (date) => {
+    const res = await fetch(`/api/schedule?date=${date}`);
+    if (!res.ok) throw new Error('Failed to fetch schedule');
+    const data = await res.json();
+    dispatch({ type: 'SET_SCHEDULE', payload: {
+      date,
+      planned: data.planned || [],
+      actual:  data.actual  || [],
+    }});
+    return data;
+  }, []);
+
+  const generateSchedule = useCallback(async (date) => {
+    const res = await fetch('/api/schedule/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ date }),
+    });
+    if (!res.ok) throw new Error('Failed to generate schedule');
+    const data = await res.json();
+    dispatch({ type: 'SET_PLANNED_SLOTS', payload: data.slots || [] });
+    return data.slots || [];
+  }, []);
+
+  const upsertSlot = useCallback(async (slotData) => {
+    const res = await fetch('/api/schedule/slots', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
+      body: JSON.stringify(slotData),
     });
-    if (!res.ok) throw new Error('Failed to upsert override');
-    const override = await res.json();
-    dispatch({ type: 'UPSERT_OVERRIDE', payload: override });
-    return override;
+    if (!res.ok) throw new Error('Failed to upsert slot');
+    const slot = await res.json();
+    dispatch({ type: 'UPSERT_SLOT', payload: slot });
+    return slot;
   }, []);
 
   return (
@@ -220,7 +274,7 @@ export function AppProvider({ children }) {
       createMission, updateMission, deleteMission,
       updateAllotments,
       addSubtask, updateSubtask, deleteSubtask,
-      upsertOverride,
+      fetchSchedule, generateSchedule, upsertSlot,
     }}>
       {children}
     </AppContext.Provider>

--- a/frontend/src/pages/PlannerPage.jsx
+++ b/frontend/src/pages/PlannerPage.jsx
@@ -4,6 +4,7 @@ import { CATEGORIES, CATEGORY_COLORS, PRIORITY_COLORS, fmtMinutes } from '../uti
 import TaskModal from '../components/TaskModal.jsx';
 import MissionModal from '../components/MissionModal.jsx';
 import AllotmentModal from '../components/AllotmentModal.jsx';
+import ScheduleGrid from '../components/ScheduleGrid.jsx';
 import './PlannerPage.css';
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -239,13 +240,9 @@ export default function PlannerPage() {
           <AllotmentConfig onEdit={() => setAllotModal(true)} />
         </aside>
 
-        {/* Main area (placeholder for Feature 3 schedule) */}
+        {/* Main area — daily schedule grid */}
         <main className="planner-main">
-          <div className="schedule-placeholder glass-card">
-            <div className="schedule-placeholder-icon">📅</div>
-            <h2>Schedule</h2>
-            <p>Daily schedule view coming in the next feature.</p>
-          </div>
+          <ScheduleGrid />
         </main>
       </div>
 


### PR DESCRIPTION
Feature #3 for Issue #9

## Changes

### AppContext.jsx
- Replaced `overrides` state with `schedule: { date, planned, actual }`
- New reducer cases: `SET_SCHEDULE`, `SET_PLANNED_SLOTS`, `UPSERT_SLOT`
- On app init: fetches `GET /api/schedule?date=today`; if `planned.length === 0`, silently calls generate (no spinner, no user action needed)
- New actions exposed: `fetchSchedule(date)`, `generateSchedule(date)`, `upsertSlot(data)`

### ScheduleGrid.jsx (NEW)
- Renders all 96 time slots from 12:00 AM to 11:45 PM in 15-min increments
- Each row: **Time** | **Task / Label** (with category color dot) | **Description**
- Occupied rows: 4px colored left border using `CATEGORY_COLORS[task.category]`
- Empty rows: dimmed italic em-dash
- Header: formatted date, Plan/Actual toggle (local state), Generate Schedule button with spinner + error feedback

### ScheduleGrid.css (NEW)
- Dark glassmorphism consistent with existing app theme
- Sticky column headers, scrollable body, custom scrollbar
- Category dot + left border for occupied rows

### PlannerPage.jsx
- Imports and renders `<ScheduleGrid />` in place of the schedule-placeholder div

## Acceptance Criteria
- [x] All 96 time rows render (12:00 AM to 11:45 PM)
- [x] Occupied rows show task name, description, and category color
- [x] Opening app with no schedule auto-generates one without user interaction
- [x] Generate button regenerates schedule on demand
- [x] Plan/Actual toggle present (actual editing is Feature 4)

Build: vite build ✓ (40 modules, no warnings)

---
*Created by Antigravity Dev Agent*