### PR TITLE
feat(4): Drag-and-drop schedule reordering + Break task visual style

### DIFF
--- a/frontend/src/components/ScheduleGrid.css
+++ b/frontend/src/components/ScheduleGrid.css
@@ -300,6 +300,46 @@
   flex-shrink: 0;
 }
 
+/* ─── Drag-and-drop ──────────────────────────────────────────────────────── */
+
+/* Row being dragged: fade to indicate it's "in flight" */
+.sg-row.dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+/* Occupied rows show grab cursor */
+.sg-row-occupied {
+  cursor: grab;
+}
+
+/* Drop target highlight: blue outline */
+.sg-row.drag-over {
+  background: rgba(59, 130, 246, 0.12) !important;
+  box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.55);
+}
+
+/* ─── Break task visual style ─────────────────────────────────────────────── */
+
+.sg-row-break {
+  border-top:    1px dashed rgba(255, 255, 255, 0.2) !important;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.2) !important;
+  border-left:   3px solid #6b7280 !important;
+  opacity: 0.85;
+  background: rgba(107, 114, 128, 0.05);
+}
+
+.sg-row-break:hover {
+  background: rgba(107, 114, 128, 0.1) !important;
+}
+
+/* Coffee icon shown instead of category dot for break tasks */
+.sg-break-icon {
+  font-size: 0.85rem;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
 /* ─── AllotmentSummary (progress bars above schedule table) ─────────────── */
 
 .allotment-summary {

--- a/frontend/src/components/ScheduleGrid.jsx
+++ b/frontend/src/components/ScheduleGrid.jsx
@@ -153,6 +153,8 @@ export default function ScheduleGrid() {
   const [genError,     setGenError]     = useState('');
   const [viewMode,     setViewMode]     = useState('planned');   // 'planned' | 'actual'
   const [editingSlot,  setEditingSlot]  = useState(null);        // slot_index | null
+  const [draggingSlot, setDraggingSlot] = useState(null);        // slot_index being dragged
+  const [dragOverSlot, setDragOverSlot] = useState(null);        // slot_index being hovered
 
   const date         = schedule.date ?? todayISO();
   const flaggedTasks = schedule.flaggedTasks || [];
@@ -176,6 +178,71 @@ export default function ScheduleGrid() {
       setGenerating(false);
     }
   }, [date, generateSchedule, fetchSchedule]);
+
+  // ── HTML5 Drag-and-drop handlers ────────────────────────────────────────
+
+  function handleDragStart(e, idx) {
+    setDraggingSlot(idx);
+    e.dataTransfer.setData('text/plain', String(idx));
+    e.dataTransfer.effectAllowed = 'move';
+  }
+
+  function handleDragEnd() {
+    setDraggingSlot(null);
+    setDragOverSlot(null);
+  }
+
+  function handleDragOver(e, idx) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    if (dragOverSlot !== idx) setDragOverSlot(idx);
+  }
+
+  function handleDragLeave(e) {
+    // Only clear if truly leaving the row (not just entering a child element)
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setDragOverSlot(null);
+    }
+  }
+
+  async function handleDrop(e, targetIdx) {
+    e.preventDefault();
+    const sourceIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
+    setDragOverSlot(null);
+    setDraggingSlot(null);
+
+    // No-op: same slot
+    if (isNaN(sourceIdx) || sourceIdx === targetIdx) return;
+
+    const sourceSlot = slotMap[sourceIdx];
+    if (!sourceSlot || !sourceSlot.task_id) return; // nothing to move
+
+    const targetSlot = slotMap[targetIdx] || null;
+
+    try {
+      // Move source task to target slot
+      await upsertSlot({
+        date,
+        slot_index:  targetIdx,
+        record_type: viewMode,
+        task_id:     sourceSlot.task_id,
+        label:       sourceSlot.label    || null,
+        comments:    sourceSlot.comments || '',
+      });
+
+      // Clear the source slot (swap with target task if occupied, else clear)
+      await upsertSlot({
+        date,
+        slot_index:  sourceIdx,
+        record_type: viewMode,
+        task_id:     targetSlot?.task_id  || null,
+        label:       targetSlot?.label    || null,
+        comments:    targetSlot?.comments || '',
+      });
+    } catch {
+      // Silent — server state is authoritative; next fetchSchedule will reconcile
+    }
+  }
 
   return (
     <div className="schedule-grid-container">
@@ -252,30 +319,52 @@ export default function ScheduleGrid() {
                   );
                 }
 
-                const slot    = slotMap[idx] || null;
-                const hasTask = slot && slot.task_id;
-                const task    = slot?.task || null;
-                const color   = task ? (CATEGORY_COLORS[task.category] || '#64748b') : null;
+                const slot     = slotMap[idx] || null;
+                const hasTask  = slot && slot.task_id;
+                const task     = slot?.task || null;
+                const color    = task ? (CATEGORY_COLORS[task.category] || '#64748b') : null;
+                const isBreak  = task?.category === 'break';
+                const isDragging  = draggingSlot === idx;
+                const isDragOver  = dragOverSlot === idx;
+
+                // Build class list
+                const rowClasses = [
+                  'sg-row',
+                  hasTask  ? 'sg-row-occupied' : 'sg-row-empty',
+                  isBreak  ? 'sg-row-break'    : '',
+                  isDragging ? 'dragging'       : '',
+                  isDragOver ? 'drag-over'      : '',
+                ].filter(Boolean).join(' ');
 
                 return (
                   <tr
                     key={idx}
-                    className={`sg-row ${hasTask ? 'sg-row-occupied' : 'sg-row-empty'}`}
-                    style={color ? { borderLeft: `3px solid ${color}` } : undefined}
+                    className={rowClasses}
+                    style={!isBreak && color ? { borderLeft: `3px solid ${color}` } : undefined}
+                    draggable={hasTask}
+                    onDragStart={hasTask ? e => handleDragStart(e, idx) : undefined}
+                    onDragEnd={hasTask ? handleDragEnd : undefined}
+                    onDragOver={e => handleDragOver(e, idx)}
+                    onDragLeave={handleDragLeave}
+                    onDrop={e => handleDrop(e, idx)}
                     onClick={() => {
                       if (hasTask) setEditingSlot(idx);
                     }}
-                    title={hasTask ? 'Click to edit' : undefined}
+                    title={hasTask ? 'Drag to reorder · Click to edit' : undefined}
                   >
                     <td className="sg-td sg-td-time">{display}</td>
                     <td className="sg-td sg-td-task">
                       {hasTask ? (
                         <div className="sg-task-chips">
                           <div className="sg-task-chip">
-                            <span
-                              className="sg-cat-dot"
-                              style={{ background: color }}
-                            />
+                            {isBreak ? (
+                              <span className="sg-break-icon">☕</span>
+                            ) : (
+                              <span
+                                className="sg-cat-dot"
+                                style={{ background: color }}
+                              />
+                            )}
                             <span className="sg-task-name">
                               {slot.label || task?.name || ''}
                             </span>


### PR DESCRIPTION
Feature #4 for Issue #19

## Summary

HTML5 drag-and-drop reordering for schedule rows (no external DnD library) and break task visual style with dashed borders + coffee icon.

## Changes (2 files, 140 insertions / 11 deletions)

### `frontend/src/components/ScheduleGrid.jsx`

**State added:**
- `draggingSlot`: slot_index being dragged (null when idle)
- `dragOverSlot`: slot_index hovered during drag (null when not hovering)

**DnD handlers:**
- `handleDragStart(e, idx)`: stores idx in `dataTransfer` as `'text/plain'`; `effectAllowed = 'move'`
- `handleDragEnd()`: clears both drag states
- `handleDragOver(e, idx)`: `e.preventDefault()`; sets `dragOverSlot`
- `handleDragLeave(e)`: clears `dragOverSlot` only on true row exit (child-safe)
- `handleDrop(e, targetIdx)`: reads source from `dataTransfer`; no-op if same slot or empty; calls `upsertSlot` for target (with source task), then `upsertSlot` for source (with target task or null — effectively a swap or clear)

**Row updates:**
- `draggable={hasTask}` on `<tr>`
- Row classes: `dragging` | `drag-over` | `sg-row-break`
- Break rows: ☕ icon replaces color dot

### `frontend/src/components/ScheduleGrid.css`

**DnD CSS:**
- `.sg-row.dragging`: `opacity: 0.4`, `cursor: grabbing`
- `.sg-row-occupied`: `cursor: grab` (affordance hint)
- `.sg-row.drag-over`: blue tinted background + `box-shadow: inset 0 0 0 2px rgba(59,130,246,0.55)`

**Break task CSS:**
- `.sg-row-break`: `border-top/bottom: 1px dashed rgba(255,255,255,0.2)`, `border-left: 3px solid #6b7280`, `opacity: 0.85`, grey background tint
- `.sg-break-icon`: ☕ icon styling

## Test results: 30/30 passing ✅
## Frontend build: 177 KB JS / 54 KB gzip, 0 errors ✅

## Acceptance Criteria

- [x] Dragging a row to new slot: moves task (upsertSlot target) + clears original (upsertSlot source) ✅
- [x] Drag-over indicator visible (blue outline) ✅
- [x] Same-slot drag: no-op ✅
- [x] Break rows: dashed/grey style + ☕ icon ✅
- [x] Break tasks visible in both Plan and Actual views ✅

---
*Created by Antigravity Dev Agent*