### PR TITLE
feat(1): Duration-aware sidebar-to-schedule drag with capacity warning

### DIFF
--- a/frontend/src/pages/PlannerPage.css
+++ b/frontend/src/pages/PlannerPage.css
@@ -720,3 +720,47 @@
   font-size: 1rem;
 }
 .sg-empty-icon { font-size: 2rem; }
+
+/* ─── Capacity Warning Banner ─────────────────────────────────────────────── */
+
+.capacity-warning-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  background: #FEF3C7;
+  border-left: 4px solid var(--accent);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  margin-bottom: 8px;
+  font-size: 0.88rem;
+  color: #92400E;
+  animation: warning-slide-in 0.2s ease;
+}
+
+@keyframes warning-slide-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.capacity-warning-icon {
+  flex-shrink: 0;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.capacity-warning-message {
+  flex: 1;
+  line-height: 1.5;
+}
+
+.capacity-warning-dismiss {
+  flex-shrink: 0;
+  color: #92400E;
+  opacity: 0.7;
+  padding: 2px 6px;
+  margin-top: -2px;
+}
+.capacity-warning-dismiss:hover {
+  opacity: 1;
+  background: rgba(146, 64, 14, 0.1);
+}

--- a/frontend/src/pages/PlannerPage.jsx
+++ b/frontend/src/pages/PlannerPage.jsx
@@ -228,7 +228,7 @@ function AllotmentConfig({ onEdit }) {
 // PlannerPage — single DndContext for sidebar AND schedule drag
 // ──────────────────────────────────────────────────────────────────────────────
 export default function PlannerPage() {
-  const { loading, deleteTask, deleteMission, schedule, upsertSlot, upsertSlotBatch } = useApp();
+  const { loading, tasks, deleteTask, deleteMission, schedule, upsertSlot, upsertSlotBatch } = useApp();
 
   const [selectedMission, setSelectedMission] = useState(null);
 
@@ -247,6 +247,10 @@ export default function PlannerPage() {
 
   // Shaking slot (rejected drop) — unified for sidebar and schedule drops
   const [shakingSlot, setShakingSlot] = useState(null);
+
+  // Capacity warning banner (sidebar → schedule drop fails)
+  const [capacityWarning, setCapacityWarning] = useState(null);
+  const capacityWarningTimer = useRef(null);
 
   const [taskModal,    setTaskModal]    = useState(null);
   const [missionModal, setMissionModal] = useState(null);
@@ -305,18 +309,40 @@ export default function PlannerPage() {
       const slotIdx = parseInt(String(over.id).replace('drop-', ''), 10);
       if (isNaN(slotIdx)) return;
 
-      const targetSlot = slotMap[slotIdx];
-      if (targetSlot && targetSlot.task_id) {
+      // Duration-aware multi-slot fill
+      // sidebarDragTask still references the captured closure value (setState is async)
+      const droppedTask = sidebarDragTask;
+      const taskName    = droppedTask?.name || 'Task';
+      const slotsNeeded = Math.ceil((droppedTask?.estimated_minutes || 30) / 15);
+      const requiredSlots = Array.from({ length: slotsNeeded }, (_, i) => slotIdx + i);
+
+      // Validate: all required slots within schedule window and unoccupied
+      const allValid = requiredSlots.every(
+        s => s >= START_SLOT_IDX && s <= END_SLOT_IDX && !(slotMap[s]?.task_id)
+      );
+
+      if (!allValid) {
+        // Count consecutive available (unoccupied + in-range) slots from slotIdx
+        let available = 0;
+        for (let s = slotIdx; s <= END_SLOT_IDX; s++) {
+          if (slotMap[s]?.task_id) break;
+          available++;
+        }
         triggerShake(slotIdx);
+        if (capacityWarningTimer.current) clearTimeout(capacityWarningTimer.current);
+        setCapacityWarning({ taskName, needed: slotsNeeded, available });
+        capacityWarningTimer.current = setTimeout(() => setCapacityWarning(null), 4000);
         return;
       }
 
-      upsertSlot({
-        date,
-        slot_index:  slotIdx,
-        record_type: viewMode,
-        task_id:     taskId,
-      }).catch(() => {});
+      // Build batch: first slot gets task name, subsequent slots get '[cont.]' label
+      const batchSlots = requiredSlots.map((s, i) => ({
+        slot_index: s,
+        task_id:    taskId,
+        label:      i === 0 ? null : '[cont.]',
+        comments:   '',
+      }));
+      upsertSlotBatch({ date, record_type: viewMode, slots: batchSlots }).catch(() => {});
 
     } else if (id.startsWith('slot-')) {
       // ── Schedule row drag ───────────────────────────────────────────────
@@ -493,6 +519,28 @@ export default function PlannerPage() {
           </aside>
 
           <main className="planner-main">
+            {capacityWarning && (
+              <div className="capacity-warning-banner">
+                <span className="capacity-warning-icon">⚠️</span>
+                <span className="capacity-warning-message">
+                  <strong>{capacityWarning.taskName}</strong> needs{' '}
+                  {capacityWarning.needed} slot{capacityWarning.needed !== 1 ? 's' : ''}{' '}
+                  ({capacityWarning.needed * 15} min) but only{' '}
+                  {capacityWarning.available} consecutive slot{capacityWarning.available !== 1 ? 's' : ''}{' '}
+                  available here.
+                </span>
+                <button
+                  className="capacity-warning-dismiss btn btn-ghost btn-icon btn-sm"
+                  onClick={() => {
+                    clearTimeout(capacityWarningTimer.current);
+                    setCapacityWarning(null);
+                  }}
+                  aria-label="Dismiss"
+                >
+                  ✕
+                </button>
+              </div>
+            )}
             <ScheduleGrid
               ref={scheduleGridRef}
               viewMode={viewMode}


### PR DESCRIPTION
Feature #1 for Issue #36

## Changes (2 files, 101 insertions / 9 deletions)

### `frontend/src/pages/PlannerPage.jsx`

**New state:**
- `const [capacityWarning, setCapacityWarning] = useState(null)` — banner data
- `const capacityWarningTimer = useRef(null)` — auto-dismiss handle
- `tasks` added to `useApp()` destructure

**`handleDragEnd` — sidebar `task-*` branch rewritten:**
- `slotsNeeded = Math.ceil((task.estimated_minutes || 30) / 15)` — 15-min slots
- `requiredSlots = Array.from({length:slotsNeeded}, (_,i) => slotIdx+i)`
- Validate: every slot within `[START_SLOT_IDX..END_SLOT_IDX]` AND `!(slotMap[s]?.task_id)`
- **Failure:** count consecutive available slots; `triggerShake(slotIdx)`; show `capacityWarning`; auto-dismiss in 4s; `return`
- **Success:** build `batchSlots` — first slot `label:null`, rest `label:'[cont.]'`; call `upsertSlotBatch`

**Warning banner JSX** (above ScheduleGrid):
- Shows: task name, needed slots (×15min), available consecutive slots
- ✕ button: immediate dismiss (clears timer)
- Auto-dismisses after 4s

### `frontend/src/pages/PlannerPage.css`
- `.capacity-warning-banner`: bg `#FEF3C7`, `border-left:4px solid var(--accent)`, amber text, no shadow
- `@keyframes warning-slide-in`: fade+slide 0.2s
- `.capacity-warning-dismiss` hover style

## Acceptance Criteria
- [x] 60-min task fills 4 slots (first with task name, rest `[cont.]`) ✅
- [x] Occupied/out-of-range drop shows accurate banner ✅
- [x] Banner auto-dismisses after 4s ✅
- [x] ✕ dismisses immediately ✅
- [x] Within-schedule single-row drag unchanged ✅

## Build
- 226 KB / 70 KB gzip, 0 errors

## Checks: 33/33 passing

---
*Created by Antigravity Dev Agent*