### PR TITLE
feat(2): Ctrl+Click multi-select (replace shift+click)

### DIFF
--- a/frontend/src/components/ScheduleGrid.jsx
+++ b/frontend/src/components/ScheduleGrid.jsx
@@ -253,24 +253,24 @@ const ScheduleGrid = forwardRef(function ScheduleGrid(
   function handleRowClick(e, idx, hasTask) {
     if (creatingSlot !== null || editingSlot !== null) return;
 
-    if (e.shiftKey && lastClicked !== null) {
-      const lo = Math.min(lastClicked, idx);
-      const hi = Math.max(lastClicked, idx);
+    if (e.ctrlKey || e.metaKey) {
+      // Ctrl+Click (or Cmd+Click on Mac): toggle selection without opening any form
+      e.preventDefault();
+      e.stopPropagation();
       setSelectedSlots(prev => {
         const next = new Set(prev);
-        for (let i = lo; i <= hi; i++) next.add(i);
+        next.has(idx) ? next.delete(idx) : next.add(idx);
         return next;
       });
-    } else if (selectedSlots.size > 0 && !e.shiftKey) {
-      setSelectedSlots(new Set());
       setLastClicked(idx);
-      if (hasTask) setEditingSlot(idx);
-      else setCreatingSlot(idx);
-    } else {
-      setLastClicked(idx);
-      if (hasTask) setEditingSlot(idx);
-      else setCreatingSlot(idx);
+      return;
     }
+
+    // Plain click: clear selection, then handle slot action
+    if (selectedSlots.size > 0) setSelectedSlots(new Set());
+    setLastClicked(idx);
+    if (hasTask) setEditingSlot(idx);
+    else setCreatingSlot(idx);
   }
 
   return (


### PR DESCRIPTION
Feature #2 for Issue #36

## Changes (1 file, 12 insertions / 12 deletions)

### `frontend/src/components/ScheduleGrid.jsx` — `handleRowClick` rewrite

**Removed:** `e.shiftKey` range-select block

**Added: Ctrl+Click toggle**
```js
if (e.ctrlKey || e.metaKey) {
  e.preventDefault();
  e.stopPropagation();
  setSelectedSlots(prev => {
    const next = new Set(prev);
    next.has(idx) ? next.delete(idx) : next.add(idx);
    return next;
  });
  setLastClicked(idx);
  return;
}
```

**Updated: plain click** — clears selection → `setLastClicked(idx)` → opens `editingSlot` or `creatingSlot`

**Unchanged:** mobile long-press selection; multi-row drag via `upsertSlotBatch`

## Acceptance Criteria
- [x] Ctrl+click toggles selection without opening any form ✅
- [x] Ctrl+clicking selected slot deselects it ✅
- [x] Regular click clears selection ✅
- [x] Shift+click no longer selects a range ✅
- [x] Multi-row drag of selected slots still works ✅

## Build: 226 KB / 70 KB gzip, 0 errors
## Checks: 14/14 passing

---
*Created by Antigravity Dev Agent*