### PR TITLE
feat(1): Rename Smart Planner to Waypoint in UI

### DIFF
--- a/backend/src/services/openrouter.js
+++ b/backend/src/services/openrouter.js
@@ -15,7 +15,7 @@
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1/chat/completions';
 const MODEL = 'google/gemini-3.1-flash-lite-preview';
 const REFERER = 'https://github.com/tonydevar/smart-planner';
-const APP_TITLE = 'Smart Planner';
+const APP_TITLE = 'Waypoint';
 
 // ─── Heuristic fallback (ported from ai-helper.js) ───────────────────────────
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Smart Planner</title>
+    <title>Waypoint</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/frontend/src/pages/PlannerPage.jsx
+++ b/frontend/src/pages/PlannerPage.jsx
@@ -481,7 +481,7 @@ export default function PlannerPage() {
     return (
       <div className="planner-loading">
         <span className="spinner" style={{ width: 32, height: 32 }} />
-        <span>Loading Smart Planner…</span>
+        <span>Loading Waypoint…</span>
       </div>
     );
   }
@@ -506,7 +506,7 @@ export default function PlannerPage() {
               {sidebarOpen ? '◀' : '☰'}
             </button>
             <span className="planner-logo-icon">🧠</span>
-            <span className="planner-logo-text">Smart Planner</span>
+            <span className="planner-logo-text">Waypoint</span>
           </div>
           <div className="planner-header-actions">
             <button


### PR DESCRIPTION
Feature #1 for Issue #41

## Changes (3 files, 4 insertions / 4 deletions)

### `frontend/index.html`
- `<title>Smart Planner</title>` → `<title>Waypoint</title>`

### `frontend/src/pages/PlannerPage.jsx`
- `'Loading Smart Planner…'` → `'Loading Waypoint…'`
- Logo span: `'Smart Planner'` → `'Waypoint'`

### `backend/src/services/openrouter.js`
- `APP_TITLE = 'Smart Planner'` → `'Waypoint'` (cosmetic: X-Title HTTP header to OpenRouter API)

## Verification
- `grep -r 'Smart Planner' frontend/src/ frontend/index.html` → zero results ✅
- `frontend/dist/index.html` contains `<title>Waypoint</title>` after rebuild ✅

## Acceptance Criteria
- [x] Browser tab shows 'Waypoint' ✅
- [x] Header logo text reads 'Waypoint' ✅
- [x] Loading screen reads 'Loading Waypoint…' ✅
- [x] grep returns zero results for 'Smart Planner' in frontend sources ✅
- [x] dist/index.html contains `<title>Waypoint</title>` ✅

## Build: 227 KB / 71 KB gzip, 0 errors

---
*Created by Karakuri Dev Agent*