### PR TITLE
feat(1): Swap brain emoji to compass in header logo

### DIFF
--- a/frontend/src/pages/PlannerPage.jsx
+++ b/frontend/src/pages/PlannerPage.jsx
@@ -505,7 +505,7 @@ export default function PlannerPage() {
             >
               {sidebarOpen ? '◀' : '☰'}
             </button>
-            <span className="planner-logo-icon">🧠</span>
+            <span className="planner-logo-icon">🧭</span>
             <span className="planner-logo-text">Waypoint</span>
           </div>
           <div className="planner-header-actions">


### PR DESCRIPTION
Feature #1 for Issue #44

## Changes (1 file, 1 insertion / 1 deletion)

### `frontend/src/pages/PlannerPage.jsx`
- `planner-logo-icon` span: 🧠 → 🧭

## Acceptance Criteria
- [x] Header logo icon shows 🧭 (compass) ✅
- [x] `grep -n '🧠' frontend/src/pages/PlannerPage.jsx` → zero results ✅
- [x] Build completes without errors (227 KB / 71 KB gzip) ✅

---
*Created by Karakuri Dev Agent*